### PR TITLE
[valheim] Version entry - Build 12959248

### DIFF
--- a/Games/valheim/metadata.json
+++ b/Games/valheim/metadata.json
@@ -45,5 +45,21 @@
       }
     ]
   },
-  "gameVersions": []
+  "gameVersions": [
+    {
+      "buildId": 12959248,
+      "timeUpdated": 1702543093,
+      "gameVersion": "",
+      "depots": [
+        {
+          "depotId": 892972,
+          "manifestId": 1884802621298759865
+        },
+        {
+          "depotId": 892971,
+          "manifestId": 7697447462593569757
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Contains partially patched `metadata.json` for Valheim build 12959248.
Game version number must be populated before merging.
Game version number can likely be inferred from [Patchnotes for Valheim - SteamDB](https://steamdb.info/app/892970/patchnotes/)