### PR TITLE
[lethal-company] Version entry - Build 18689725

### DIFF
--- a/Games/lethal-company/versions/18689725.json
+++ b/Games/lethal-company/versions/18689725.json
@@ -1,0 +1,26 @@
+{
+  "buildId": 18689725,
+  "timeUpdated": 1748749418,
+  "gameVersion": "",
+  "depots": [
+    {
+      "depotId": 1966721,
+      "manifestId": 1239725417627278072
+    }
+  ],
+  "frameworkTargets": [
+    {
+      "tfm": "netstandard2.1",
+      "dependencies": [
+        {
+          "name": "UnityEngine.Modules",
+          "version": "2022.3.9"
+        },
+        {
+          "name": "Newtonsoft.JSON",
+          "version": "13.0.3"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Contains partially patched `metadata.json` for Lethal Company build 18689725.
Game version number must be populated before merging.
Game version number can likely be inferred from [Patchnotes for Lethal Company - SteamDB](https://steamdb.info/app/1966720/patchnotes/)